### PR TITLE
Performance & Compatibility Updates

### DIFF
--- a/dependencies/nodejs/package.json
+++ b/dependencies/nodejs/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "aws-sdk": "^2.368.0",
-    "iiif-processor": "^0.2.4",
+    "iiif-processor": "~0.3.1",
     "middy": "^0.19.4"
   }
 }

--- a/src/package.json
+++ b/src/package.json
@@ -7,7 +7,7 @@
   "dependencies": {},
   "devDependencies": {
     "aws-sdk": "^2.368.0",
-    "iiif-processor": "^0.2.4",
+    "iiif-processor": "~0.3.1",
     "middy": "^0.19.4"
   }
 }


### PR DESCRIPTION
* Use dimension metadata if the S3 object has it
* Use the `X-Forwarded-Host` header instead of `Host` if present [Fixes #11]